### PR TITLE
[NNBD] Bugfix: Currencies with high precision

### DIFF
--- a/lib/src/currency.dart
+++ b/lib/src/currency.dart
@@ -58,7 +58,7 @@ class Currency {
 
   /// The factor of 10 to divide a minor value by to get the intended
   /// currency value.
-  ///  e.g. if minorDigits is 1 then this value will be 100.
+  ///  e.g. if minorDigits is 2 then this value will be 100.
   final BigInt minorDigitsFactor;
 
   /// the default pattern used to format and parse monetary amounts for this

--- a/lib/src/pattern_encoder.dart
+++ b/lib/src/pattern_encoder.dart
@@ -212,13 +212,13 @@ class PatternEncoder implements MoneyEncoder<String> {
     var minorUnits = data.getMinorUnits();
     // format the no. into that pattern.
     // in order for Number format to format single digit minor unit properly
-    // with proper 0s, we first add 100 and then strip the 1 after being
-    // formatted.
+    // with proper 0s, we first add [minorDigitsFactor] and then strip the 1
+    // after being formatted.
     //
     // e.g., using ## to format 1 would result in 1, but we want it
     // formatted as 01 because it is really the decimal part of the number.
     var formattedMinorUnits = NumberFormat(moneyPattern)
-        .format(minorUnits.toInt() + 100)
+        .format((minorUnits + data.currency.minorDigitsFactor).toInt())
         .substring(1);
     if (moneyPattern.length < formattedMinorUnits.length) {
       // money pattern is short, so we need to force a truncation as

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,13 @@
 name: money2
-version: 2.0.0-nonnullable.1
+version: 2.0.1-nonnullable.1
 homepage: https://github.com/noojee/money.dart
 description: Money and Currency classes with fixed precision maths, parsing and formating. (Money.parse(\"$2010.00\") * 10).format(\"S CC#,##0\") -> $ US20,100
 
-environment: 
-  sdk: '>=2.9.0-15.0.dev <3.0.0'
-dependencies: 
-  intl: ^0.16.0
-  meta: ^1.1.8
-dev_dependencies: 
+environment:
+  sdk: ">=2.12.0-0 <3.0.0"
+dependencies:
+  intl: ^0.17.0-nullsafety.2
+  meta: ^1.3.0-nullsafety.6
+dev_dependencies:
   effective_dart: ^1.2.1
-  test: ^1.6.1
+  test: ^1.16.0-nullsafety.11

--- a/test/money_format_test.dart
+++ b/test/money_format_test.dart
@@ -31,10 +31,12 @@ void main() {
   final euro = Currency.create('EUR', 2,
       symbol: '€', invertSeparators: true, pattern: 'S0,00');
   final long = Currency.create('LONG', 2);
+  final bitcoin = Currency.create('BTC', 8);
 
   final usd10d25 = Money.fromInt(1025, usd);
   final usd10 = Money.fromInt(1000, usd);
   final long1000d90 = Money.fromInt(100090, long);
+  final btc1satoshi = Money.fromInt(1, bitcoin);
 
   group('format', () {
     test('Simple Number', () {
@@ -48,6 +50,7 @@ void main() {
       expect(usd10d25.format('###,000.##'), equals('010.25'));
       expect(usd10d25.format('##.##'), equals('10.25'));
       expect(usd10d25.format('##'), equals('10'));
+      expect(btc1satoshi.format('0.00000000'), equals('0.00000001'));
     });
 
     test('Inverted Decimal Separator', () {

--- a/test/money_parse_test.dart
+++ b/test/money_parse_test.dart
@@ -62,6 +62,18 @@ void main() {
       expect(Money.parse('1.000,25', euro, pattern: '#.###,00'),
           equals(Money.fromInt(100025, euro)));
     });
+
+    test(
+        'Decode and encode with the same currency should be inverse operations',
+        () {
+      for (var precision = 2; precision < 5; precision++) {
+        final currency = Currency.create('MONEY', precision,
+            pattern: '0.${'0' * precision} CCC');
+        final stringValue = '1025.${'0' * (precision - 1)}1 MONEY';
+        expect(
+            Money.parse(stringValue, currency).toString(), equals(stringValue));
+      }
+    });
   });
 
   group('Currency.parse', () {


### PR DESCRIPTION
Fix a formatting issue where currencies with precision>2 were outputting weird numbers.

Same as https://github.com/noojee/money.dart/pull/19, but on non-nullable branch.