### PR TITLE
Correctly parse currencies with 0 minor digits

### DIFF
--- a/lib/src/currency.dart
+++ b/lib/src/currency.dart
@@ -58,7 +58,7 @@ class Currency {
 
   /// The factor of 10 to divide a minor value by to get the intended
   /// currency value.
-  ///  e.g. if minorDigits is 1 then this value will be 100.
+  ///  e.g. if minorDigits is 2 then this value will be 100.
   final BigInt minorDigitsFactor;
 
   /// the default pattern used to format and parse monetary amounts for this

--- a/lib/src/pattern_decoder.dart
+++ b/lib/src/pattern_decoder.dart
@@ -110,7 +110,8 @@ class PatternDecoder implements MoneyDecoder<String> {
 
     var result = '';
 
-    var regExPattern = '([#|0|$thousandsSeparator]+)$decimalSeparator([#|0]+)';
+    var regExPattern =
+        '([#|0|$thousandsSeparator]+)(?:$decimalSeparator([#|0]+))?';
 
     var regEx = RegExp(regExPattern);
 
@@ -129,14 +130,12 @@ class PatternDecoder implements MoneyDecoder<String> {
 
     Match match = matches.first;
 
-    if (match.group(0) != null && match.group(1) != null) {
+    if (match.group(1) != null && match.group(2) != null) {
       result = pattern.replaceFirst(regEx, '#.#');
-      // result += '#';
-    } else if (match.group(0) != null) {
-      result = pattern.replaceFirst(regEx, '#');
     } else if (match.group(1) != null) {
+      result = pattern.replaceFirst(regEx, '#');
+    } else if (match.group(2) != null) {
       result = pattern.replaceFirst(regEx, '.#');
-      // result += '.#';
     }
     return result;
   }

--- a/lib/src/pattern_encoder.dart
+++ b/lib/src/pattern_encoder.dart
@@ -219,13 +219,13 @@ class PatternEncoder implements MoneyEncoder<String> {
     var minorUnits = data.getMinorUnits();
     // format the no. into that pattern.
     // in order for Number format to format single digit minor unit properly
-    // with proper 0s, we first add 100 and then strip the 1 after being
-    // formatted.
+    // with proper 0s, we first add [minorDigitsFactor] and then strip the 1
+    // after being formatted.
     //
     // e.g., using ## to format 1 would result in 1, but we want it
     // formatted as 01 because it is really the decimal part of the number.
     var formattedMinorUnits = NumberFormat(moneyPattern)
-        .format(minorUnits.toInt() + 100)
+        .format((minorUnits + data.currency.minorDigitsFactor).toInt())
         .substring(1);
     if (moneyPattern.length < formattedMinorUnits.length) {
       // money pattern is short, so we need to force a truncation as

--- a/test/money_format_test.dart
+++ b/test/money_format_test.dart
@@ -31,11 +31,13 @@ void main() {
   final euro = Currency.create('EUR', 2,
       symbol: '€', invertSeparators: true, pattern: 'S0,00');
   final long = Currency.create('LONG', 2);
+  final bitcoin = Currency.create('BTC', 8);
 
   final usd10d25 = Money.fromInt(1025, usd);
   final usd10 = Money.fromInt(1000, usd);
   final long1000d90 = Money.fromInt(100090, long);
   final usd20cents = Money.fromInt(20, usd);
+  final btc1satoshi = Money.fromInt(1, bitcoin);
 
   group('format', () {
     test('Simple Number', () {
@@ -50,6 +52,7 @@ void main() {
       expect(usd10d25.format('##.##'), equals('10.25'));
       expect(usd10d25.format('##'), equals('10'));
       expect(usd20cents.format('#,##0.00'), equals('0.20'));
+      expect(btc1satoshi.format('0.00000000'), equals('0.00000001'));
     });
 
     test('Negative Number', () {

--- a/test/money_parse_test.dart
+++ b/test/money_parse_test.dart
@@ -93,7 +93,12 @@ void main() {
     test(
         'Decode and encode with the same currency should be inverse operations',
         () {
-      for (var precision = 2; precision < 5; precision++) {
+      final currency = Currency.create('MONEY', 0, pattern: '0 CCC');
+      final stringValue = '1025 MONEY';
+      expect(
+          Money.parse(stringValue, currency).toString(), equals(stringValue));
+
+      for (var precision = 1; precision < 5; precision++) {
         final currency = Currency.create('MONEY', precision,
             pattern: '0.${'0' * precision} CCC');
         final stringValue = '1025.${'0' * (precision - 1)}1 MONEY';

--- a/test/money_parse_test.dart
+++ b/test/money_parse_test.dart
@@ -89,6 +89,18 @@ void main() {
       expect(Money.parse('-1.000,25', euro, pattern: '#.###,00'),
           equals(Money.fromInt(-100025, euro)));
     });
+
+    test(
+        'Decode and encode with the same currency should be inverse operations',
+        () {
+      for (var precision = 2; precision < 5; precision++) {
+        final currency = Currency.create('MONEY', precision,
+            pattern: '0.${'0' * precision} CCC');
+        final stringValue = '1025.${'0' * (precision - 1)}1 MONEY';
+        expect(
+            Money.parse(stringValue, currency).toString(), equals(stringValue));
+      }
+    });
   });
 
   group('Currency.parse', () {


### PR DESCRIPTION
Depends on https://github.com/noojee/money.dart/pull/19 (but this PR would merge them both)