### PR TITLE
Add API to access currently registered currencies

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -160,4 +160,9 @@ void main() {
 
   print(taxInclusivePrice.format('SCC 0.00'));
   // $US 11.00
+
+  // retrieve all registered currencies
+  final Iterable<String> registeredCurrencies = Currencies.getRegistered();
+  print(registeredCurrencies);
+  // (USD, AUD, EUR, JPY)
 }

--- a/example/example.dart
+++ b/example/example.dart
@@ -162,7 +162,8 @@ void main() {
   // $US 11.00
 
   // retrieve all registered currencies
-  final Iterable<String> registeredCurrencies = Currencies.getRegistered();
-  print(registeredCurrencies);
+  final Iterable<Currency> registeredCurrencies = Currencies.getRegistered();
+  final Iterable<String> codes = registeredCurrencies.map((c) => c.code);
+  print(codes);
   // (USD, AUD, EUR, JPY)
 }

--- a/lib/src/currencies.dart
+++ b/lib/src/currencies.dart
@@ -159,9 +159,9 @@ class Currencies {
     return _directory[code];
   }
 
-  /// Returns the [code]s of all registered [Currency]s
-  static Iterable<String> getRegistered() {
-    return _directory.keys;
+  /// Returns all currently registered [Currency]s
+  static Iterable<Currency> getRegistered() {
+    return _directory.values;
   }
 
   /// Counts the number of 'C' in a pattern

--- a/lib/src/currencies.dart
+++ b/lib/src/currencies.dart
@@ -159,6 +159,11 @@ class Currencies {
     return _directory[code];
   }
 
+  /// Returns the [code]s of all registered [Currency]s
+  static Iterable<String> getRegistered() {
+    return _directory.keys;
+  }
+
   /// Counts the number of 'C' in a pattern
   static int _getCodeLength(String pattern) {
     var count = 0;

--- a/test/currencies/currencies_test.dart
+++ b/test/currencies/currencies_test.dart
@@ -44,7 +44,7 @@ void main() {
     });
 
     test('returns all currencies correctly', () {
-      expect(Currencies.getRegistered(), ['USD', 'EUR']);
+      expect(Currencies.getRegistered(), [usd, eur]);
     });
   });
 }

--- a/test/currencies/currencies_test.dart
+++ b/test/currencies/currencies_test.dart
@@ -42,5 +42,9 @@ void main() {
     test('returns null if a currency cannot be found', () {
       expect(Currencies.find('BTC'), isNull);
     });
+
+    test('returns all currencies correctly', () {
+      expect(Currencies.getRegistered(), ['USD', 'EUR']);
+    });
   });
 }


### PR DESCRIPTION
This should make it easier to build currency selection in some kind of settings page.

Unsure if it's best to return `Iterable<Currency>` instead of `Iterable<String>`. `Iterable<String>` fits my use case perfectly as I wanted to provide users with a list of all available currencies that they can set as active in my app. I could see cases where developers want to map the registered currencies to the symbol `$, €, ...` instead of the code though.