### PR TITLE
increase fixed dependency to fix web problems

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.13.0 <3.0.0'
 dependencies: 
   decimal: ^1.3.0
-  fixed: ^1.0.3
+  fixed: ^1.1.0
   intl: ^0.17.0
   meta: ^1.7.0
 dev_dependencies: 


### PR DESCRIPTION
With the version 1.1.0 of fixed a web bug is fixed.

> Fixed #7 We now include platform specific defs of max and min ints as the web version of dart ints are only 53 bits.